### PR TITLE
feat: add custom Clojure fork testing support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,52 +8,8 @@ on:
 
 jobs:
   gradle-test:
-    name: Gradle Test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-    steps:
-      - name: Pick and set a random system-wide time zone
-        run: |
-          TZ_LIST=$(timedatectl list-timezones)
-          RANDOM_TZ=$(echo "$TZ_LIST" | shuf -n 1)
-          echo "Randomly selected time zone: $RANDOM_TZ"
-
-          # Set system time zone
-          sudo ln -snf /usr/share/zoneinfo/$RANDOM_TZ /etc/localtime
-          echo "$RANDOM_TZ" | sudo tee /etc/timezone
-          sudo dpkg-reconfigure -f noninteractive tzdata
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
-
-      - name: Test
-        run: ./gradlew test
-        timeout-minutes: 15
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
-        if: success() || failure() # always run even if the previous step fails
-        with:
-          check_name: JUnit Test Report
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Post Slack Notification (On Fail)
-        if: failure() && github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2.5.0
-        with:
-          status: ${{ job.status }}
-          notification_title: "*{workflow}* has {status_message}:"
-          message_format: "{emoji} `gradle-test` job has {status_message} in *{workflow}*"
-          notify_when: "failure"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    uses: ./.github/workflows/gradle-test.yml
+    secrets: inherit
 
   lang-test:
     name: Non-JVM language tests
@@ -123,41 +79,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   integration-test:
-    name: Integration Test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
-
-      - name: Integration Test
-        run: ./gradlew integration-test
-        timeout-minutes: 15
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
-        if: success() || failure() # always run even if the previous step fails
-        with:
-          check_name: JUnit Integration Test Report
-          report_paths: '**/build/test-results/integration-test/TEST-*.xml'
-      - name: Post Slack Notification (On Fail)
-        if: failure() && github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2.5.0
-        with:
-          status: ${{ job.status }}
-          notification_title: "*{workflow}* has {status_message}:"
-          message_format: "{emoji} `integration-test` job has {status_message} in *{workflow}*"
-          notify_when: "failure"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    uses: ./.github/workflows/integration-test.yml
+    secrets: inherit
 
   slt-1:
     name: SLT 1

--- a/.github/workflows/custom-clojure-test.yml
+++ b/.github/workflows/custom-clojure-test.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       clojure_version:
-        description: 'Custom Clojure fork version (e.g. 1.12.0-xtdb-fork)'
+        description: 'JitPack coordinates of the fork (e.g. com.github.YOUR_ORG:clojure:v1.12.0)'
         required: true
         type: string
 
@@ -17,7 +17,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      packages: read
 
     steps:
       - name: Pick and set a random system-wide time zone
@@ -42,13 +41,6 @@ jobs:
       - name: Test with custom Clojure fork
         run: ./gradlew test -PcustomClojure=${{ inputs.clojure_version }}
         timeout-minutes: 15
-        env:
-          # Set this repository variable to the GitHub Packages Maven URL of the fork,
-          # e.g. https://maven.pkg.github.com/YOUR_ORG/clojure
-          CLOJURE_FORK_MAVEN_URL: ${{ vars.CLOJURE_FORK_MAVEN_URL }}
-          GITHUB_ACTOR: ${{ github.actor }}
-          # GITHUB_TOKEN grants read access to packages on the same org automatically.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0

--- a/.github/workflows/custom-clojure-test.yml
+++ b/.github/workflows/custom-clojure-test.yml
@@ -6,97 +6,18 @@ on:
 
 jobs:
   gradle-test-custom-clojure:
-    name: Gradle Test (Custom Clojure Fork)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      checks: write
-
-    steps:
-      - name: Pick and set a random system-wide time zone
-        run: |
-          TZ_LIST=$(timedatectl list-timezones)
-          RANDOM_TZ=$(echo "$TZ_LIST" | shuf -n 1)
-          echo "Randomly selected time zone: $RANDOM_TZ"
-
-          sudo ln -snf /usr/share/zoneinfo/$RANDOM_TZ /etc/localtime
-          echo "$RANDOM_TZ" | sudo tee /etc/timezone
-          sudo dpkg-reconfigure -f noninteractive tzdata
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
-
-      - name: Test with custom Clojure fork
-        run: ./gradlew test -PdisableSmallMapsOptimisation
-        timeout-minutes: 15
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
-        if: success() || failure()
-        with:
-          check_name: JUnit Test Report (Custom Clojure Fork)
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+    uses: ./.github/workflows/gradle-test.yml
+    with:
+      extra_gradle_flags: '-PdisableSmallMapsOptimisation'
 
   integration-test-custom-clojure:
-    name: Integration Test (Custom Clojure Fork)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      checks: write
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
-
-      - name: Integration Test with custom Clojure fork
-        run: ./gradlew integration-test -PdisableSmallMapsOptimisation
-        timeout-minutes: 15
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
-        if: success() || failure()
-        with:
-          check_name: JUnit Integration Test Report (Custom Clojure Fork)
-          report_paths: '**/build/test-results/integration-test/TEST-*.xml'
+    uses: ./.github/workflows/integration-test.yml
+    with:
+      extra_gradle_flags: '-PdisableSmallMapsOptimisation'
 
   property-test-custom-clojure:
-    name: Property Test (Custom Clojure Fork)
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-      checks: write
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
-
-      - name: Property Test with custom Clojure fork
-        run: ./gradlew property-test -PdisableSmallMapsOptimisation
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
-        if: always()
-        with:
-          check_name: JUnit Property Test Report (Custom Clojure Fork)
-          report_paths: '**/build/test-results/property-test/TEST-*.xml'
+    uses: ./.github/workflows/property-test.yml
+    with:
+      iteration_count: "100"
+      simulation_iteration_count: "100"
+      extra_gradle_flags: '-PdisableSmallMapsOptimisation'

--- a/.github/workflows/custom-clojure-test.yml
+++ b/.github/workflows/custom-clojure-test.yml
@@ -1,0 +1,58 @@
+name: Custom Clojure Fork Tests
+run-name: Custom Clojure Fork Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      clojure_version:
+        description: 'Custom Clojure fork version (e.g. 1.12.0-xtdb-fork)'
+        required: true
+        type: string
+
+jobs:
+  gradle-test-custom-clojure:
+    name: Gradle Test (Custom Clojure Fork)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      checks: write
+      packages: read
+
+    steps:
+      - name: Pick and set a random system-wide time zone
+        run: |
+          TZ_LIST=$(timedatectl list-timezones)
+          RANDOM_TZ=$(echo "$TZ_LIST" | shuf -n 1)
+          echo "Randomly selected time zone: $RANDOM_TZ"
+
+          sudo ln -snf /usr/share/zoneinfo/$RANDOM_TZ /etc/localtime
+          echo "$RANDOM_TZ" | sudo tee /etc/timezone
+          sudo dpkg-reconfigure -f noninteractive tzdata
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
+
+      - name: Test with custom Clojure fork
+        run: ./gradlew test -PcustomClojure=${{ inputs.clojure_version }}
+        timeout-minutes: 15
+        env:
+          # Set this repository variable to the GitHub Packages Maven URL of the fork,
+          # e.g. https://maven.pkg.github.com/YOUR_ORG/clojure
+          CLOJURE_FORK_MAVEN_URL: ${{ vars.CLOJURE_FORK_MAVEN_URL }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          # GITHUB_TOKEN grants read access to packages on the same org automatically.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
+        if: success() || failure()
+        with:
+          check_name: JUnit Test Report (Custom Clojure Fork)
+          report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/custom-clojure-test.yml
+++ b/.github/workflows/custom-clojure-test.yml
@@ -43,3 +43,60 @@ jobs:
         with:
           check_name: JUnit Test Report (Custom Clojure Fork)
           report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  integration-test-custom-clojure:
+    name: Integration Test (Custom Clojure Fork)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      checks: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
+
+      - name: Integration Test with custom Clojure fork
+        run: ./gradlew integration-test -PdisableSmallMapsOptimisation
+        timeout-minutes: 15
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
+        if: success() || failure()
+        with:
+          check_name: JUnit Integration Test Report (Custom Clojure Fork)
+          report_paths: '**/build/test-results/integration-test/TEST-*.xml'
+
+  property-test-custom-clojure:
+    name: Property Test (Custom Clojure Fork)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      checks: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
+
+      - name: Property Test with custom Clojure fork
+        run: ./gradlew property-test -PdisableSmallMapsOptimisation
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
+        if: always()
+        with:
+          check_name: JUnit Property Test Report (Custom Clojure Fork)
+          report_paths: '**/build/test-results/property-test/TEST-*.xml'

--- a/.github/workflows/custom-clojure-test.yml
+++ b/.github/workflows/custom-clojure-test.yml
@@ -3,11 +3,6 @@ run-name: Custom Clojure Fork Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      clojure_version:
-        description: 'JitPack coordinates of the fork (e.g. com.github.YOUR_ORG:clojure:v1.12.0)'
-        required: true
-        type: string
 
 jobs:
   gradle-test-custom-clojure:
@@ -39,7 +34,7 @@ jobs:
         uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
 
       - name: Test with custom Clojure fork
-        run: ./gradlew test -PcustomClojure=${{ inputs.clojure_version }}
+        run: ./gradlew test -PdisableSmallMapsOptimisation
         timeout-minutes: 15
 
       - name: Publish Test Report

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -1,0 +1,62 @@
+name: XTDB Gradle Test
+
+on:
+  workflow_call:
+    inputs:
+      extra_gradle_flags:
+        description: 'Extra flags appended to ./gradlew test'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false
+
+jobs:
+  gradle-test:
+    name: Gradle Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Pick and set a random system-wide time zone
+        run: |
+          TZ_LIST=$(timedatectl list-timezones)
+          RANDOM_TZ=$(echo "$TZ_LIST" | shuf -n 1)
+          echo "Randomly selected time zone: $RANDOM_TZ"
+
+          # Set system time zone
+          sudo ln -snf /usr/share/zoneinfo/$RANDOM_TZ /etc/localtime
+          echo "$RANDOM_TZ" | sudo tee /etc/timezone
+          sudo dpkg-reconfigure -f noninteractive tzdata
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
+
+      - name: Test
+        run: ./gradlew test ${{ inputs.extra_gradle_flags }}
+        timeout-minutes: 15
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
+        if: success() || failure()
+        with:
+          check_name: JUnit Test Report
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+      - name: Post Slack Notification (On Fail)
+        if: failure() && github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/main'
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2.5.0
+        with:
+          status: ${{ job.status }}
+          notification_title: "*{workflow}* has {status_message}:"
+          message_format: "{emoji} `gradle-test` job has {status_message} in *{workflow}*"
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,51 @@
+name: XTDB Integration Test
+
+on:
+  workflow_call:
+    inputs:
+      extra_gradle_flags:
+        description: 'Extra flags appended to ./gradlew integration-test'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false
+
+jobs:
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
+
+      - name: Integration Test
+        run: ./gradlew integration-test ${{ inputs.extra_gradle_flags }}
+        timeout-minutes: 15
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
+        if: success() || failure()
+        with:
+          check_name: JUnit Integration Test Report
+          report_paths: '**/build/test-results/integration-test/TEST-*.xml'
+      - name: Post Slack Notification (On Fail)
+        if: failure() && github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/main'
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2.5.0
+        with:
+          status: ${{ job.status }}
+          notification_title: "*{workflow}* has {status_message}:"
+          message_format: "{emoji} `integration-test` job has {status_message} in *{workflow}*"
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/no-small-maps-test.yml
+++ b/.github/workflows/no-small-maps-test.yml
@@ -1,7 +1,9 @@
-name: Custom Clojure Fork Tests
-run-name: Custom Clojure Fork Tests
+name: No Small Maps Tests
+run-name: No Small Maps Tests
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/property-test.yml
+++ b/.github/workflows/property-test.yml
@@ -11,6 +11,11 @@ on:
         description: 'Number of simulation test iterations to run'
         required: true
         type: string
+      extra_gradle_flags:
+        description: 'Extra flags appended to ./gradlew property-test'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   property-test:
@@ -32,7 +37,7 @@ jobs:
         uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
 
       - name: Property Test
-        run: ./gradlew property-test -Piterations=${{ inputs.iteration_count }} -PsimulationIterations=${{ inputs.simulation_iteration_count }}
+        run: ./gradlew property-test -Piterations=${{ inputs.iteration_count }} -PsimulationIterations=${{ inputs.simulation_iteration_count }} ${{ inputs.extra_gradle_flags }}
 
       - name: Publish Property Test Report
         uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,10 +93,12 @@ val buildCustomJre = jlinkBuild.task(":buildCustomJre")
 val customJreDir = jlinkBuild.projectDir.resolve("build/custom-jre")
 val useCustomJre = !rootProj.hasProperty("fullJdk")
 
-// Pass full JitPack coordinates to substitute org.clojure:clojure with a fork,
-// e.g. -PcustomClojure=com.github.YOUR_ORG:clojure:v1.12.0
-// JitPack builds directly from a public GitHub tag or commit hash - no auth or publishing step needed.
-val customClojureVersion = rootProj.findProperty("customClojure") as String?
+// JitPack commit hash for juxt/no-small-maps-clojure; update when pulling in a new revision.
+val noSmallMapsClojureCommit = "REPLACE_WITH_COMMIT_HASH"
+
+// Pass -PdisableSmallMapsOptimisation to substitute org.clojure:clojure with the
+// juxt/no-small-maps-clojure fork, served via JitPack with no auth required.
+val disableSmallMapsOptimisation = rootProj.hasProperty("disableSmallMapsOptimisation")
 
 fun Project.customJreLauncher(): Provider<JavaLauncher> {
     val toolchainLauncher = extensions.getByType(JavaToolchainService::class.java)
@@ -119,19 +121,17 @@ allprojects {
     version = System.getenv("XTDB_VERSION") ?: "2.x-SNAPSHOT"
 
     repositories {
-        if (customClojureVersion != null) {
-            maven { url = uri("https://jitpack.io") }
-        }
+        maven { url = uri("https://jitpack.io") }
         mavenCentral()
         maven { url = uri("https://repo.clojars.org/") }
     }
 
-    if (!customClojureVersion.isNullOrEmpty()) {
+    if (disableSmallMapsOptimisation) {
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module("org.clojure:clojure"))
-                    .using(module(customClojureVersion))
-                    .because("custom Clojure fork testing (-PcustomClojure=<jitpack-coordinates>)")
+                    .using(module("com.github.juxt:no-small-maps-clojure:$noSmallMapsClojureCommit"))
+                    .because("testing juxt/no-small-maps-clojure fork via JitPack (-PdisableSmallMapsOptimisation)")
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,11 @@ val buildCustomJre = jlinkBuild.task(":buildCustomJre")
 val customJreDir = jlinkBuild.projectDir.resolve("build/custom-jre")
 val useCustomJre = !rootProj.hasProperty("fullJdk")
 
+// Pass e.g. -PcustomClojure=1.12.0-xtdb-fork to substitute org.clojure:clojure with the fork.
+// For local dev: run `mvn install` in the fork repo first (uses mavenLocal).
+// For CI: set CLOJURE_FORK_MAVEN_URL to the GitHub Packages URL of the fork repo.
+val customClojureVersion = rootProj.findProperty("customClojure") as String?
+
 fun Project.customJreLauncher(): Provider<JavaLauncher> {
     val toolchainLauncher = extensions.getByType(JavaToolchainService::class.java)
         .launcherFor(java.toolchain)
@@ -114,8 +119,32 @@ allprojects {
     version = System.getenv("XTDB_VERSION") ?: "2.x-SNAPSHOT"
 
     repositories {
+        if (customClojureVersion != null) {
+            // Local install takes priority - run `mvn install` in the fork repo for local dev.
+            mavenLocal()
+            val forkMavenUrl = System.getenv("CLOJURE_FORK_MAVEN_URL")
+            if (forkMavenUrl != null) {
+                maven {
+                    url = uri(forkMavenUrl)
+                    credentials {
+                        username = System.getenv("GITHUB_ACTOR") ?: ""
+                        password = System.getenv("GITHUB_TOKEN") ?: ""
+                    }
+                }
+            }
+        }
         mavenCentral()
         maven { url = uri("https://repo.clojars.org/") }
+    }
+
+    if (!customClojureVersion.isNullOrEmpty()) {
+        configurations.all {
+            resolutionStrategy.dependencySubstitution {
+                substitute(module("org.clojure:clojure"))
+                    .using(module("org.clojure:clojure:$customClojureVersion"))
+                    .because("custom Clojure fork testing (-PcustomClojure=<version>)")
+            }
+        }
     }
 
     if (plugins.hasPlugin("java-library")) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,9 +93,9 @@ val buildCustomJre = jlinkBuild.task(":buildCustomJre")
 val customJreDir = jlinkBuild.projectDir.resolve("build/custom-jre")
 val useCustomJre = !rootProj.hasProperty("fullJdk")
 
-// Pass e.g. -PcustomClojure=1.12.0-xtdb-fork to substitute org.clojure:clojure with the fork.
-// For local dev: run `mvn install` in the fork repo first (uses mavenLocal).
-// For CI: set CLOJURE_FORK_MAVEN_URL to the GitHub Packages URL of the fork repo.
+// Pass full JitPack coordinates to substitute org.clojure:clojure with a fork,
+// e.g. -PcustomClojure=com.github.YOUR_ORG:clojure:v1.12.0
+// JitPack builds directly from a public GitHub tag or commit hash - no auth or publishing step needed.
 val customClojureVersion = rootProj.findProperty("customClojure") as String?
 
 fun Project.customJreLauncher(): Provider<JavaLauncher> {
@@ -120,18 +120,7 @@ allprojects {
 
     repositories {
         if (customClojureVersion != null) {
-            // Local install takes priority - run `mvn install` in the fork repo for local dev.
-            mavenLocal()
-            val forkMavenUrl = System.getenv("CLOJURE_FORK_MAVEN_URL")
-            if (forkMavenUrl != null) {
-                maven {
-                    url = uri(forkMavenUrl)
-                    credentials {
-                        username = System.getenv("GITHUB_ACTOR") ?: ""
-                        password = System.getenv("GITHUB_TOKEN") ?: ""
-                    }
-                }
-            }
+            maven { url = uri("https://jitpack.io") }
         }
         mavenCentral()
         maven { url = uri("https://repo.clojars.org/") }
@@ -141,8 +130,8 @@ allprojects {
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module("org.clojure:clojure"))
-                    .using(module("org.clojure:clojure:$customClojureVersion"))
-                    .because("custom Clojure fork testing (-PcustomClojure=<version>)")
+                    .using(module(customClojureVersion))
+                    .because("custom Clojure fork testing (-PcustomClojure=<jitpack-coordinates>)")
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,11 +93,6 @@ val buildCustomJre = jlinkBuild.task(":buildCustomJre")
 val customJreDir = jlinkBuild.projectDir.resolve("build/custom-jre")
 val useCustomJre = !rootProj.hasProperty("fullJdk")
 
-// JitPack commit hash for juxt/no-small-maps-clojure; update when pulling in a new revision.
-val noSmallMapsClojureCommit = "REPLACE_WITH_COMMIT_HASH"
-
-// Pass -PdisableSmallMapsOptimisation to substitute org.clojure:clojure with the
-// juxt/no-small-maps-clojure fork, served via JitPack with no auth required.
 val disableSmallMapsOptimisation = rootProj.hasProperty("disableSmallMapsOptimisation")
 
 fun Project.customJreLauncher(): Provider<JavaLauncher> {
@@ -130,7 +125,7 @@ allprojects {
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module("org.clojure:clojure"))
-                    .using(module("com.github.juxt:no-small-maps-clojure:$noSmallMapsClojureCommit"))
+                    .using(module("com.github.juxt:no-small-maps-clojure:REPLACE_WITH_COMMIT_HASH"))
                     .because("testing juxt/no-small-maps-clojure fork via JitPack (-PdisableSmallMapsOptimisation)")
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,9 +116,9 @@ allprojects {
     version = System.getenv("XTDB_VERSION") ?: "2.x-SNAPSHOT"
 
     repositories {
-        maven { url = uri("https://jitpack.io") }
         mavenCentral()
         maven { url = uri("https://repo.clojars.org/") }
+        maven { url = uri("https://jitpack.io") }
     }
 
     if (disableSmallMapsOptimisation) {


### PR DESCRIPTION
Adds a -PcustomClojure=<version> Gradle flag that swaps out
org.clojure:clojure with a fork artifact across all modules via
dependency substitution.

For local dev, install the fork with `mvn install` first (mavenLocal
takes priority).
For CI, set the CLOJURE_FORK_MAVEN_URL repo variable to the GitHub
Packages Maven URL of the fork; GITHUB_TOKEN provides authentication.

Also adds a manual workflow_dispatch GitHub Actions workflow
(.github/workflows/custom-clojure-test.yml) that runs the full test
suite with the fork substituted in.

https://claude.ai/code/session_01SPzDgCcWoMiNtQiUmirYED